### PR TITLE
Support IMDSv2 

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
@@ -154,8 +155,34 @@ func logHandler(handler func(w http.ResponseWriter, r *http.Request)) func(w htt
 	}
 }
 
+func fetchMetadataToken() (string, error) {
+	var token = ""
+	req, err := http.NewRequest(http.MethodPut, "http://169.254.169.254/latest/api/token", nil)
+	if err != nil {
+		log.Error("Error making request for fetching metadata token: ", err)
+		return token, err
+	}
+	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "300")
+	resp, err := client.Do(req)
+	if resp.StatusCode == http.StatusOK {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Error("Error reading response body from fetching metadata token: ", err)
+		}
+		token = string(bodyBytes)
+	}
+	defer resp.Body.Close()
+	return token, err
+}
+
 func newGET(path string) *http.Request {
+	token, err := fetchMetadataToken()
+	if err != nil {
+		panic(err)
+	}
+
 	r, err := http.NewRequest("GET", path, nil)
+	r.Header.Set("X-aws-ec2-metadata-token", token)
 
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ var (
 	credsRegex = regexp.MustCompile("^/(.+?)/meta-data/iam/security-credentials/(.*)$")
 
 	instanceServiceClient = &http.Transport{}
+	
+	client = &http.Client{}
 )
 
 var (


### PR DESCRIPTION
AWS is deprecating IMDSv1 and encourage to use IMDSv2 to fetch instance metadata: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html 

To support IMDSv2, the function needs to get a token before request data from the metadata url. 