### PR TITLE
Support IMDSv2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
-FROM alpine
+FROM golang:1.17.6-alpine3.14 as builder
+
+WORKDIR /app
+COPY . .
+RUN go mod init
+RUN go mod tidy -compat=1.17
+RUN go mod vendor
+RUN go build -o bin/ec2metaproxy
+
+
+FROM alpine:3.14
 
 MAINTAINER Cory Thomas <cthomas7577@gmail.com>
 
 RUN apk add --no-cache ca-certificates
-
-COPY ec2metaproxy /bin/ec2metaproxy
+COPY --from=builder /app/bin/ec2metaproxy /bin/ec2metaproxy
 
 ENTRYPOINT ["/bin/ec2metaproxy"]


### PR DESCRIPTION
AWS is deprecating IMDSv1 and recommend to use IMDSv2 to improve the level of security. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html 

In this PR: 
* Add method to get token and assign it to header before get instance metadata. 
* Modify Dockerfile to support multi-build stages and use go 1.17 to build it. 
